### PR TITLE
Added caching of neo4j to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,22 @@
 sudo: required
 dist: trusty
 language: java
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
+
+jdk:
+  - oraclejdk8
 
 env:
   global:
-
     - NEO4J_VERSION=3.1.3 NEO4J_HOSTNAME=127.0.0.1 NEO4J_PORT=7474 NEO4J_USERNAME=neo4j NEO4J_PASSWORD=test NEO4J_HOME=neo4j-community-$NEO4J_VERSION
-before_install:
-  - curl http://dist.neo4j.org/neo4j-community-$NEO4J_VERSION-unix.tar.gz | tar xz
-install:
-  - $NEO4J_HOME/bin/neo4j-admin set-initial-password test
-  - $NEO4J_HOME/bin/neo4j start
 
-before_script:
-  # When Neo4j is started the first time, it requires the change of the default password
-#  - curl -vX POST http://neo4j:neo4j@$NEO4J_HOSTNAME:$NEO4J_PORT/user/neo4j/password -d"password=$NEO4J_PASSWORD"
+cache:
+  directories:
+    - $NEO4J_HOME
+
+before_install:
+# Uncomment this if rebuilding cache
+#  - curl http://dist.neo4j.org/neo4j-community-$NEO4J_VERSION-unix.tar.gz | tar xz
+install:
+# Uncomment this if rebuilding cache
+#  - $NEO4J_HOME/bin/neo4j-admin set-initial-password test
+  - $NEO4J_HOME/bin/neo4j start


### PR DESCRIPTION
Travis needs a neo4j installation. This was curl'd for each build which was time consuming. Now the installation will be cached.