### PR TITLE
Pagination support for all requests

### DIFF
--- a/src/main/java/com/atypon/wayf/dao/QueryMapper.java
+++ b/src/main/java/com/atypon/wayf/dao/QueryMapper.java
@@ -17,6 +17,8 @@
 package com.atypon.wayf.dao;
 
 
+import com.atypon.wayf.dao.neo4j.Neo4JExecutor;
+import com.google.common.collect.Sets;
 import org.apache.commons.beanutils.BeanUtilsBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +29,8 @@ import java.util.regex.Pattern;
 
 public class QueryMapper {
     private static final Logger LOG = LoggerFactory.getLogger(QueryMapper.class);
+
+    private static final Set<String> FIELD_BLACKLIST = Sets.newHashSet(Neo4JExecutor.LIMIT, Neo4JExecutor.OFFSET);
 
     private static final String DELIMITER = ".";
     private static final String REGEX_DELIMITER = "\\.";
@@ -61,7 +65,11 @@ public class QueryMapper {
 
             while (result.find()) {
                 for (int i = 1; i <= result.groupCount(); i++) {
-                    parsedQuery.add(result.group(i));
+                    String field = result.group(i);
+
+                    if (!FIELD_BLACKLIST.contains(field)) {
+                        parsedQuery.add(field);
+                    }
                 }
             }
 

--- a/src/main/java/com/atypon/wayf/dao/neo4j/Neo4JExecutor.java
+++ b/src/main/java/com/atypon/wayf/dao/neo4j/Neo4JExecutor.java
@@ -90,7 +90,7 @@ public class Neo4JExecutor {
 
             if (result != null && result.hasNext()) {
                 List<Record> records = result.list();
-                
+
                 // Check to see if there was more data to paginate over
                 if (records.size() > RequestContextAccessor.get().getLimit()) {
                     RequestContextAccessor.get().setHasAnotherDbPage(Boolean.TRUE);

--- a/src/main/java/com/atypon/wayf/dao/neo4j/Neo4JExecutor.java
+++ b/src/main/java/com/atypon/wayf/dao/neo4j/Neo4JExecutor.java
@@ -17,13 +17,11 @@
 package com.atypon.wayf.dao.neo4j;
 
 import com.atypon.wayf.dao.ResultSetProcessor;
+import com.atypon.wayf.request.RequestContextAccessor;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.reactivex.Observable;
-import org.neo4j.driver.v1.Driver;
-import org.neo4j.driver.v1.Record;
-import org.neo4j.driver.v1.Session;
-import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +33,9 @@ import java.util.Map;
 public class Neo4JExecutor {
     private static final Logger LOG = LoggerFactory.getLogger(Neo4JExecutor.class);
 
+    public static final String LIMIT = "limit";
+    public static final String OFFSET = "offset";
+
     @Inject
     private Driver driver;
 
@@ -44,27 +45,62 @@ public class Neo4JExecutor {
         processor = new ResultSetProcessor();
     }
 
+    public Driver getDriver() {
+        return driver;
+    }
+
     public <T> T executeQuerySelectFirst(String query, Map<String, Object> arguments, Class<T> returnType) {
         LOG.debug("Running statement[{}] with values[{}]", query, arguments);
 
-        try (Session session = driver.session()) {
-            StatementResult result = session.run(query, arguments);
+        List<Record> records =  execute(query, arguments);
 
-            return (returnType != null && result.hasNext())? processor.processRow(result.next().asMap(), returnType) : null;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        if (records != null && records.size() > 0) {
+            try {
+                processor.processRow(records.get(0).asMap(), returnType);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
+
+        return null;
     }
 
     public <T> Observable<T> executeQuery(String query, Map<String, Object> arguments, Class<T> returnType) {
         LOG.debug("Running statement[{}] with values[{}]", query, arguments);
 
+        List<Record> records = execute(query, arguments);
 
-        try (Session session = driver.session()){
+        return records == null?
+                Observable.empty() :
+                Observable.fromIterable(records)
+                    .map((record) -> processor.processRow(record.asMap(), returnType));
+    }
+
+    private List<Record> execute(String query, Map<String, Object> arguments) {
+        LOG.debug("Running statement[{}] with values[{}]", query, arguments);
+
+        // Add in limit and offset arguments by default. The limit is increased by 1 so that we can see if there is
+        // more data for the client to paginate
+        arguments.put(LIMIT, RequestContextAccessor.get().getLimit() + 1);
+        arguments.put(OFFSET, RequestContextAccessor.get().getOffset());
+
+        try (Session session = driver.session()) {
             StatementResult result = session.run(query, arguments);
 
-            return Observable.fromIterable(result.list())
-                    .map((record) -> processor.processRow(record.asMap(), returnType));
+            if (result != null && result.hasNext()) {
+                List<Record> records = result.list();
+
+                LOG.debug("Record size {} limit {}", records.size(), RequestContextAccessor.get().getLimit());
+                // Check to see if there is more data to paginate over
+                RequestContextAccessor.get().setHasAnotherDbPage(records.size() > RequestContextAccessor.get().getLimit());
+
+                // Remove the extra record
+                records.remove(records.size() - 1);
+
+                return records;
+            }
+
+            return null;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/atypon/wayf/request/RequestContext.java
+++ b/src/main/java/com/atypon/wayf/request/RequestContext.java
@@ -17,8 +17,12 @@
 package com.atypon.wayf.request;
 
 import io.vertx.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RequestContext {
+    private static final Logger LOG = LoggerFactory.getLogger(RequestContext.class);
+
     private static final Integer DEFAULT_LIMIT = 30;
     private static final Integer DEFAULT_OFFSET = 0;
 
@@ -26,9 +30,10 @@ public class RequestContext {
     private Integer offset = DEFAULT_OFFSET;
 
     private String requestUrl;
+    private String requestUri;
     private boolean forceSync;
 
-    private Boolean hasAnotherDbPage;
+    private Boolean hasAnotherDbPage = Boolean.FALSE;
 
     public RequestContext() {
     }
@@ -36,7 +41,8 @@ public class RequestContext {
     public static RequestContext fromRoutingContext(RoutingContext routingContext) {
         RequestContext requestContext = new RequestContext();
 
-        requestContext.setRequestUrl(routingContext.request().uri());
+        requestContext.setRequestUri(routingContext.request().uri());
+        requestContext.setRequestUrl(routingContext.request().absoluteURI());
 
         String forceSyncQueryValue = RequestReader.getQueryValue(routingContext, "forceSync");
         requestContext.setForceSync(Boolean.parseBoolean(forceSyncQueryValue));
@@ -60,6 +66,15 @@ public class RequestContext {
 
     public RequestContext setRequestUrl(String requestUrl) {
         this.requestUrl = requestUrl;
+        return this;
+    }
+
+    public String getRequestUri() {
+        return requestUri;
+    }
+
+    public RequestContext setRequestUri(String requestUri) {
+        this.requestUri = requestUri;
         return this;
     }
 

--- a/src/main/java/com/atypon/wayf/request/RequestContext.java
+++ b/src/main/java/com/atypon/wayf/request/RequestContext.java
@@ -19,10 +19,18 @@ package com.atypon.wayf.request;
 import io.vertx.ext.web.RoutingContext;
 
 public class RequestContext {
+    private static final Integer DEFAULT_LIMIT = 30;
+    private static final Integer DEFAULT_OFFSET = 0;
+
+    private Integer limit = DEFAULT_LIMIT;
+    private Integer offset = DEFAULT_OFFSET;
+
     private String requestUrl;
     private boolean forceSync;
 
-    RequestContext() {
+    private Boolean hasAnotherDbPage;
+
+    public RequestContext() {
     }
 
     public static RequestContext fromRoutingContext(RoutingContext routingContext) {
@@ -32,6 +40,16 @@ public class RequestContext {
 
         String forceSyncQueryValue = RequestReader.getQueryValue(routingContext, "forceSync");
         requestContext.setForceSync(Boolean.parseBoolean(forceSyncQueryValue));
+
+        String limit = RequestReader.getQueryValue(routingContext, "limit");
+        if (limit != null) {
+            requestContext.setLimit(Integer.parseInt(limit));
+        }
+
+        String offset = RequestReader.getQueryValue(routingContext, "offset");
+        if (offset != null) {
+            requestContext.setOffset(Integer.parseInt(offset));
+        }
 
         return requestContext;
     }
@@ -54,4 +72,30 @@ public class RequestContext {
         return this;
     }
 
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public RequestContext setLimit(Integer limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    public Integer getOffset() {
+        return offset;
+    }
+
+    public RequestContext setOffset(Integer offset) {
+        this.offset = offset;
+        return this;
+    }
+
+    public Boolean getHasAnotherDbPage() {
+        return hasAnotherDbPage;
+    }
+
+    public RequestContext setHasAnotherDbPage(Boolean hasAnotherDbPage) {
+        this.hasAnotherDbPage = hasAnotherDbPage;
+        return this;
+    }
 }

--- a/src/main/resources/dao/publisher-dao-neo4j.properties
+++ b/src/main/resources/dao/publisher-dao-neo4j.properties
@@ -46,4 +46,7 @@ publisher.dao.neo4j.filter = \
             p.status AS status, \
             p.name AS name, \
             p.createdDate AS createdDate, \
-            p.modifiedDate AS modifiedDate;
+            p.modifiedDate AS modifiedDate \
+    ORDER BY p.id \
+    SKIP {offset} \
+    LIMIT {limit};

--- a/src/test/java/com/atypon/wayf/dao/QueryMapperTest.java
+++ b/src/test/java/com/atypon/wayf/dao/QueryMapperTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.dao;
+
+import com.atypon.wayf.dao.QueryMapper;
+import com.atypon.wayf.data.device.Device;
+import com.atypon.wayf.data.publisher.Publisher;
+import com.atypon.wayf.data.publisher.PublisherSession;
+import com.atypon.wayf.data.publisher.PublisherSessionStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+public class QueryMapperTest {
+
+    @Test
+    public void test() throws Exception {
+        PublisherSession publisherSession = new PublisherSession();
+        publisherSession.setId(UUID.randomUUID().toString());
+        publisherSession.setStatus(PublisherSessionStatus.ACTIVE);
+        publisherSession.setLocalId("123abc456");
+        publisherSession.setLastActiveDate(new Date());
+        publisherSession.setCreatedDate(new Date());
+        publisherSession.setModifiedDate(new Date());
+
+        Device device = new Device();
+        device.setId(UUID.randomUUID().toString());
+        publisherSession.setDevice(device);
+
+        Publisher publisher = new Publisher();
+        publisher.setId(UUID.randomUUID().toString());
+        publisherSession.setPublisher(publisher);
+
+        Map<String, Object> arguments = QueryMapper.buildQueryArguments("    MATCH (d:Device {id: {device.id}}) \\\n" +
+                "    MATCH (p:Publisher {id: {`publisher.id`}}) \\\n" +
+                "    CREATE (ps:PublisherSession {\\\n" +
+                "        id: {id}, \\\n" +
+                "        localId: {localId}, \\\n" +
+                "        status: {status}, \\\n" +
+                "        lastActiveDate: {lastActiveDate}, \\\n" +
+                "        createdDate: {createdDate}, \\\n" +
+                "        modifiedDate: {modifiedDate} \\\n" +
+                "    }) \\\n" +
+                "    CREATE (d)-[:HAS_SESSION]->(ps) \\\n" +
+                "    CREATE (ps)-[:VALID_FOR]->(p) \\\n" +
+                "    RETURN ps.id AS id, \\\n" +
+                "        ps.localId AS localId, \\\n" +
+                "        ps.status AS status, \\\n" +
+                "        p.id AS `publisher.id`, \\\n" +
+                "        d.id AS `device.id`, \\\n" +
+                "        ps.lastActiveDate AS lastActiveDate, \\\n" +
+                "        ps.createdDate AS createdDate, \\\n" +
+                "        ps.modifiedDate AS modifiedDate;", publisherSession);
+
+        Assert.assertEquals(publisherSession.getId(), arguments.get("id"));
+        Assert.assertEquals(publisherSession.getLocalId(), arguments.get("localId"));
+        Assert.assertEquals(publisherSession.getStatus().toString(), arguments.get("status"));
+        Assert.assertEquals(publisherSession.getLastActiveDate().getTime(), arguments.get("lastActiveDate"));
+        Assert.assertEquals(publisherSession.getDevice().getId(), arguments.get("device.id"));
+        Assert.assertEquals(publisherSession.getPublisher().getId(), arguments.get("publisher.id"));
+        Assert.assertEquals(publisherSession.getModifiedDate().getTime(), arguments.get("modifiedDate"));
+        Assert.assertEquals(publisherSession.getCreatedDate().getTime(), arguments.get("createdDate"));
+
+
+    }
+}

--- a/src/test/java/com/atypon/wayf/dao/ResultSetProcessorTest.java
+++ b/src/test/java/com/atypon/wayf/dao/ResultSetProcessorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.dao;
+
+
+import com.atypon.wayf.dao.ResultSetProcessor;
+import com.atypon.wayf.data.publisher.PublisherSession;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResultSetProcessorTest {
+
+    @Test
+    public void testResultSetProcessor() throws Exception {
+        ResultSetProcessor processor = new ResultSetProcessor();
+
+        Map<String, Object> row = new HashMap<>();
+        row.put("id", "testId");
+        row.put("device.id", "testDeviceId");
+
+        PublisherSession publisherSession = processor.processRow(row, PublisherSession.class);
+
+        Assert.assertEquals("testId", publisherSession.getId());
+        Assert.assertEquals("testDeviceId", publisherSession.getDevice().getId());
+    }
+
+
+}

--- a/src/test/java/com/atypon/wayf/dao/impl/DeviceDaoNeo4JImplTest.java
+++ b/src/test/java/com/atypon/wayf/dao/impl/DeviceDaoNeo4JImplTest.java
@@ -19,6 +19,9 @@ package com.atypon.wayf.dao.impl;
 import com.atypon.wayf.data.device.Device;
 import com.atypon.wayf.data.device.DeviceStatus;
 import com.atypon.wayf.guice.WayfGuiceModule;
+import com.atypon.wayf.reactivex.WayfReactivexConfig;
+import com.atypon.wayf.request.RequestContext;
+import com.atypon.wayf.request.RequestContextAccessor;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import org.junit.Assert;
@@ -36,6 +39,9 @@ public class DeviceDaoNeo4JImplTest {
     @Before
     public void setUp() {
         Guice.createInjector(new WayfGuiceModule()).injectMembers(this);
+
+        WayfReactivexConfig.initializePlugins();
+        RequestContextAccessor.set(new RequestContext().setLimit(5).setOffset(0));
     }
 
     @Test

--- a/src/test/java/com/atypon/wayf/dao/impl/PublisherDaoNeo4JImplTest.java
+++ b/src/test/java/com/atypon/wayf/dao/impl/PublisherDaoNeo4JImplTest.java
@@ -20,6 +20,9 @@ import com.atypon.wayf.data.publisher.Publisher;
 import com.atypon.wayf.data.publisher.PublisherFilter;
 import com.atypon.wayf.data.publisher.PublisherStatus;
 import com.atypon.wayf.guice.WayfGuiceModule;
+import com.atypon.wayf.reactivex.WayfReactivexConfig;
+import com.atypon.wayf.request.RequestContext;
+import com.atypon.wayf.request.RequestContextAccessor;
 import com.google.common.collect.Lists;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -39,6 +42,9 @@ public class PublisherDaoNeo4JImplTest {
     @Before
     public void setUp() {
         Guice.createInjector(new WayfGuiceModule()).injectMembers(this);
+
+        WayfReactivexConfig.initializePlugins();
+        RequestContextAccessor.set(new RequestContext().setLimit(5).setOffset(0));
     }
 
     @Test

--- a/src/test/java/com/atypon/wayf/dao/impl/PublisherSessionDaoNeo4JImplTest.java
+++ b/src/test/java/com/atypon/wayf/dao/impl/PublisherSessionDaoNeo4JImplTest.java
@@ -25,6 +25,9 @@ import com.atypon.wayf.data.publisher.PublisherSession;
 import com.atypon.wayf.data.publisher.PublisherSessionStatus;
 import com.atypon.wayf.data.publisher.PublisherStatus;
 import com.atypon.wayf.guice.WayfGuiceModule;
+import com.atypon.wayf.reactivex.WayfReactivexConfig;
+import com.atypon.wayf.request.RequestContext;
+import com.atypon.wayf.request.RequestContextAccessor;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import org.junit.Assert;
@@ -48,6 +51,9 @@ public class PublisherSessionDaoNeo4JImplTest {
     @Before
     public void setUp() {
         Guice.createInjector(new WayfGuiceModule()).injectMembers(this);
+
+        WayfReactivexConfig.initializePlugins();
+        RequestContextAccessor.set(new RequestContext().setLimit(5).setOffset(0));
     }
 
     @Test

--- a/src/test/java/com/atypon/wayf/dao/neo4j/MockDriver.java
+++ b/src/test/java/com/atypon/wayf/dao/neo4j/MockDriver.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.dao.neo4j;
+
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.Session;
+
+class MockDriver implements Driver {
+    private MockSession mockSession = new MockSession();
+    public MockDriver() {
+    }
+
+    @Override
+    public boolean isEncrypted() {
+        return false;
+    }
+
+    @Override
+    public Session session() {
+        return mockSession;
+    }
+
+    @Override
+    public Session session(AccessMode accessMode) {
+        return null;
+    }
+
+    @Override
+    public Session session(String s) {
+        return null;
+    }
+
+    @Override
+    public Session session(AccessMode accessMode, String s) {
+        return null;
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/src/test/java/com/atypon/wayf/dao/neo4j/MockSession.java
+++ b/src/test/java/com/atypon/wayf/dao/neo4j/MockSession.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.dao.neo4j;
+
+import com.atypon.wayf.request.RequestContextAccessor;
+import com.google.common.collect.Lists;
+import org.neo4j.driver.v1.*;
+import org.neo4j.driver.v1.exceptions.NoSuchRecordException;
+import org.neo4j.driver.v1.summary.ResultSummary;
+import org.neo4j.driver.v1.types.*;
+import org.neo4j.driver.v1.util.Function;
+import org.neo4j.driver.v1.util.Pair;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class MockSession implements Session {
+    private String lastQuery;
+    private Map<String, Object> lastArguments;
+    private Integer numRowsToReturn = 5;
+
+    public String getLastQuery() {
+        return lastQuery;
+    }
+
+    public void setLastQuery(String lastQuery) {
+        this.lastQuery = lastQuery;
+    }
+
+    public Map<String, Object> getLastArguments() {
+        return lastArguments;
+    }
+
+    public void setLastArguments(Map<String, Object> lastArguments) {
+        this.lastArguments = lastArguments;
+    }
+
+    public Integer getNumRowsToReturn() {
+        return numRowsToReturn;
+    }
+
+    public void setNumRowsToReturn(Integer numRowsToReturn) {
+        this.numRowsToReturn = numRowsToReturn;
+    }
+
+    @Override
+    public Transaction beginTransaction() {
+        return null;
+    }
+
+    @Override
+    public Transaction beginTransaction(String s) {
+        return null;
+    }
+
+    @Override
+    public <T> T readTransaction(TransactionWork<T> transactionWork) {
+        return null;
+    }
+
+    @Override
+    public <T> T writeTransaction(TransactionWork<T> transactionWork) {
+        return null;
+    }
+
+    @Override
+    public String lastBookmark() {
+        return null;
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public StatementResult run(String s, Value value) {
+        return null;
+    }
+
+    @Override
+    public StatementResult run(String s, Map<String, Object> map) {
+        lastQuery = s;
+        lastArguments = map;
+
+        return new StatementResult() {
+            @Override
+            public List<String> keys() {
+                return null;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Record next() {
+                return null;
+            }
+
+            @Override
+            public Record single() throws NoSuchRecordException {
+                return null;
+            }
+
+            @Override
+            public Record peek() {
+                return null;
+            }
+
+            @Override
+            public List<Record> list() {
+                List<Record> rows = new ArrayList<>(numRowsToReturn);
+                for (int i = 0; i < numRowsToReturn; i++) {
+                    rows.add(new Record() {
+                        @Override
+                        public List<String> keys() {
+                            return null;
+                        }
+
+                        @Override
+                        public List<Value> values() {
+                            return null;
+                        }
+
+                        @Override
+                        public boolean containsKey(String s) {
+                            return false;
+                        }
+
+                        @Override
+                        public int index(String s) {
+                            return 0;
+                        }
+
+                        @Override
+                        public Value get(String s) {
+                            return null;
+                        }
+
+                        @Override
+                        public Value get(int i) {
+                            return null;
+                        }
+
+                        @Override
+                        public int size() {
+                            return 0;
+                        }
+
+                        @Override
+                        public Map<String, Object> asMap() {
+                            return new HashMap<>();
+                        }
+
+                        @Override
+                        public <T> Map<String, T> asMap(Function<Value, T> function) {
+                            return null;
+                        }
+
+                        @Override
+                        public List<Pair<String, Value>> fields() {
+                            return null;
+                        }
+
+                        @Override
+                        public Value get(String s, Value value) {
+                            return null;
+                        }
+
+                        @Override
+                        public Object get(String s, Object o) {
+                            return null;
+                        }
+
+                        @Override
+                        public Number get(String s, Number number) {
+                            return null;
+                        }
+
+                        @Override
+                        public Entity get(String s, Entity entity) {
+                            return null;
+                        }
+
+                        @Override
+                        public Node get(String s, Node node) {
+                            return null;
+                        }
+
+                        @Override
+                        public Path get(String s, Path path) {
+                            return null;
+                        }
+
+                        @Override
+                        public Relationship get(String s, Relationship relationship) {
+                            return null;
+                        }
+
+                        @Override
+                        public List<Object> get(String s, List<Object> list) {
+                            return null;
+                        }
+
+                        @Override
+                        public <T> List<T> get(String s, List<T> list, Function<Value, T> function) {
+                            return null;
+                        }
+
+                        @Override
+                        public Map<String, Object> get(String s, Map<String, Object> map) {
+                            return null;
+                        }
+
+                        @Override
+                        public <T> Map<String, T> get(String s, Map<String, T> map, Function<Value, T> function) {
+                            return null;
+                        }
+
+                        @Override
+                        public int get(String s, int i) {
+                            return 0;
+                        }
+
+                        @Override
+                        public long get(String s, long l) {
+                            return 0;
+                        }
+
+                        @Override
+                        public boolean get(String s, boolean b) {
+                            return false;
+                        }
+
+                        @Override
+                        public String get(String s, String s1) {
+                            return null;
+                        }
+
+                        @Override
+                        public float get(String s, float v) {
+                            return 0;
+                        }
+
+                        @Override
+                        public double get(String s, double v) {
+                            return 0;
+                        }
+                    });
+                }
+                return rows;
+            }
+
+            @Override
+            public <T> List<T> list(Function<Record, T> function) {
+                return null;
+            }
+
+            @Override
+            public ResultSummary consume() {
+                return null;
+            }
+
+            @Override
+            public ResultSummary summary() {
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public StatementResult run(String s, Record record) {
+        return null;
+    }
+
+    @Override
+    public StatementResult run(String s) {
+        return null;
+    }
+
+    @Override
+    public StatementResult run(Statement statement) {
+        return null;
+    }
+
+    @Override
+    public TypeSystem typeSystem() {
+        return null;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return false;
+    }
+}

--- a/src/test/java/com/atypon/wayf/dao/neo4j/Neo4JExecutorTest.java
+++ b/src/test/java/com/atypon/wayf/dao/neo4j/Neo4JExecutorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.dao.neo4j;
+
+import com.atypon.wayf.request.RequestContext;
+import com.atypon.wayf.request.RequestContextAccessor;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.driver.v1.Driver;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Neo4JExecutorTest {
+
+    @Inject
+    private Neo4JExecutor dbExecutor;
+
+    @Before
+    public void setUp() {
+        Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(Driver.class).to(MockDriver.class);
+            }
+        }).injectMembers(this);
+
+        RequestContextAccessor.set(new RequestContext().setLimit(5).setOffset(0));
+    }
+
+    @After
+    public void tearDown() {
+        RequestContextAccessor.set(null);
+    }
+
+    @Test
+    public void testPaginationOnSingle() {
+        String cypher = "A test cypher";
+        Map<String, Object> args = new HashMap<>();
+
+        Assert.assertNull(args.get(Neo4JExecutor.LIMIT));
+        Assert.assertNull(args.get(Neo4JExecutor.OFFSET));
+
+        dbExecutor.executeQuerySelectFirst(cypher, args, Object.class);
+
+        Assert.assertEquals(RequestContextAccessor.get().getLimit() + 1, args.get(Neo4JExecutor.LIMIT));
+        Assert.assertEquals(RequestContextAccessor.get().getOffset(), args.get(Neo4JExecutor.OFFSET));
+    }
+
+    @Test
+    public void testPaginationOnMultiple() {
+        String cypher = "A test cypher";
+        Map<String, Object> args = new HashMap<>();
+
+        Assert.assertNull(args.get(Neo4JExecutor.LIMIT));
+        Assert.assertNull(args.get(Neo4JExecutor.OFFSET));
+
+        dbExecutor.executeQuery(cypher, args, Object.class);
+
+        Assert.assertEquals(RequestContextAccessor.get().getLimit() + 1, args.get(Neo4JExecutor.LIMIT));
+        Assert.assertEquals(RequestContextAccessor.get().getOffset(), args.get(Neo4JExecutor.OFFSET));
+    }
+
+    @Test
+    public void testPaginationHasMore() {
+        String cypher = "A test cypher";
+        Map<String, Object> args = new HashMap<>();
+
+        ((MockSession) ((MockDriver)dbExecutor.getDriver()).session()).setNumRowsToReturn(6);
+
+        dbExecutor.executeQuery(cypher, args, Object.class);
+
+        Assert.assertEquals(Boolean.TRUE, RequestContextAccessor.get().getHasAnotherDbPage());
+    }
+
+
+    @Test
+    public void testPaginationHasNoMore() {
+        String cypher = "A test cypher";
+        Map<String, Object> args = new HashMap<>();
+
+        ((MockSession) ((MockDriver)dbExecutor.getDriver()).session()).setNumRowsToReturn(4);
+
+        dbExecutor.executeQuery(cypher, args, Object.class);
+
+        Assert.assertEquals(Boolean.FALSE, RequestContextAccessor.get().getHasAnotherDbPage());
+    }
+
+}

--- a/src/test/java/com/atypon/wayf/dao/neo4j/Neo4JExecutorTest.java
+++ b/src/test/java/com/atypon/wayf/dao/neo4j/Neo4JExecutorTest.java
@@ -16,6 +16,7 @@
 
 package com.atypon.wayf.dao.neo4j;
 
+import com.atypon.wayf.reactivex.WayfReactivexConfig;
 import com.atypon.wayf.request.RequestContext;
 import com.atypon.wayf.request.RequestContextAccessor;
 import com.google.inject.AbstractModule;
@@ -28,7 +29,6 @@ import org.junit.Test;
 import org.neo4j.driver.v1.Driver;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class Neo4JExecutorTest {
@@ -45,6 +45,7 @@ public class Neo4JExecutorTest {
             }
         }).injectMembers(this);
 
+        WayfReactivexConfig.initializePlugins();
         RequestContextAccessor.set(new RequestContext().setLimit(5).setOffset(0));
     }
 

--- a/src/test/java/com/atypon/wayf/request/ResponseWriterTest.java
+++ b/src/test/java/com/atypon/wayf/request/ResponseWriterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.request;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ResponseWriterTest {
+    private class ResponseWriterMock extends ResponseWriter {
+        public String _getLinkHeaderValue() {
+            return super.getLinkHeaderValue();
+        }
+    }
+
+    @After
+    public void setup() {
+        RequestContextAccessor.set(null);
+    }
+
+    @Test
+    public void testHasMore() {
+        RequestContextAccessor.set(new RequestContext().setRequestUrl("http://localhost:8080/list?param1=1&limit=30&offset=0").setOffset(0).setLimit(30).setHasAnotherDbPage(Boolean.TRUE));
+        String link = new ResponseWriterMock()._getLinkHeaderValue();
+        Assert.assertEquals("<http://localhost:8080/list?param1=1&limit=30&offset=30>; rel=\"next\"", link);
+    }
+
+    @Test
+    public void testHasNoMore() {
+        RequestContextAccessor.set(new RequestContext().setRequestUrl("/list").setOffset(0).setLimit(30).setHasAnotherDbPage(Boolean.FALSE));
+        String link = new ResponseWriterMock()._getLinkHeaderValue();
+        Assert.assertNull(link);
+    }
+}


### PR DESCRIPTION
Add pagination support for all requests. Each database query will have default values of limit = 30, offset = 0 available to them. These are defined in Neo4JExecutor. The client may override these in any request via the query params "offset" and "limit" as demonstrated in RequestContext.